### PR TITLE
Dev 11435 Android and iOS Vonage SDK Upgrade to 2.26.0

### DIFF
--- a/build-extras.gradle
+++ b/build-extras.gradle
@@ -23,5 +23,5 @@ allprojects {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.opentok.android:opentok-android-sdk:2.21.4'
+    implementation 'com.opentok.android:opentok-android-sdk:2.26.0'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-opentok",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "description": "Add live video streaming to your Cordova Application",
   "cordova": {
     "id": "cordova-plugin-opentok",
@@ -11,7 +11,7 @@
     ]
   },
   "dependencies": {
-    "@opentok/client": "2.15.5",
+    "@opentok/client": "2.26.0",
     "exec": "^0.2.0",
     "q": "^1.5.1",
     "tar": "^2.0.0"

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-opentok"
-    version="3.4.6">
+    version="3.4.7">
 
     <name>OpenTokCordovaPlugin</name>
     <description>Add live video streaming to your Cordova Application</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -40,7 +40,7 @@
 
     <!-- ios -->
     <platform name="ios">
-      <framework src="OTXCFramework" type="podspec" spec="~> 2.26.0" />
+      <framework src="OTXCFramework" type="podspec" spec="~> 2.26.0" embed="true"/>
       <asset src="www/opentok.js" target="opentok.js" />
 
       <header-file src="src/ios/UIView+Category.h" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -40,7 +40,7 @@
 
     <!-- ios -->
     <platform name="ios">
-      <hook type="before_plugin_install" src="scripts/downloadiOSSDK.js" />
+      <framework src="OTXCFramework" type="podspec" spec="~> 2.26.0" />
       <asset src="www/opentok.js" target="opentok.js" />
 
       <header-file src="src/ios/UIView+Category.h" />
@@ -54,8 +54,6 @@
       <framework src="libsqlite3.dylib" />
       <framework src="libpthread.dylib" />
       <framework src="VideoToolbox.framework" />
-      <framework src="src/ios/OpenTok.framework" custom="true" />
-      <framework src="src/ios/VonageWebRTC.framework" custom="true" />
       <framework src="AudioToolbox.framework" />
       <framework src="CoreData.framework" />
       <framework src="AVFoundation.framework" />

--- a/scripts/downloadiOSSDK.js
+++ b/scripts/downloadiOSSDK.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 module.exports = function (context) {
-    var IosSDKVersion = "OpenTok-iOS-2.23.0";
+    var IosSDKVersion = "OpenTok-iOS-2.26.0";
     var downloadedSDK = "OpenTok-iOS"
     var downloadFile = require('./downloadFile.js'),
         exec = require('./exec/exec.js'),

--- a/src/android/OpenTokAndroidPlugin.java
+++ b/src/android/OpenTokAndroidPlugin.java
@@ -370,6 +370,9 @@ public class OpenTokAndroidPlugin extends CordovaPlugin
             mSubscriber = new Subscriber.Builder(cordova.getActivity().getApplicationContext(), mStream)
                     .renderer(new OpenTokCustomVideoRenderer(cordova.getActivity().getApplicationContext()))
                     .build();
+            Log.d(TAG, "When New Subscriber Created Get audio volume--> " + mSubscriber.getAudioVolume());
+            mSubscriber.setAudioVolume(100);
+            Log.d(TAG, "After setting -->When New Subscriber Created Get audio volume--> " + mSubscriber.getAudioVolume());
             mSubscriber.setVideoListener(this);
             mSubscriber.setSubscriberListener(this);
             mSubscriber.setAudioLevelListener(this);

--- a/src/ios/OpenTokPlugin.m
+++ b/src/ios/OpenTokPlugin.m
@@ -57,7 +57,7 @@
     [payload setObject:@"3.4.5" forKey:@"cp_version"];
     NSMutableDictionary *logData = [[NSMutableDictionary alloc]init];
     [logData setObject:apiKey forKey:@"partner_id"];
-    [logData setObject:@"2.23.0" forKey:@"build"];
+    [logData setObject:@"2.26.0" forKey:@"build"];
     [logData setObject:@"https://github.com/opentok/cordova-plugin-opentok" forKey:@"source"];
     [logData setObject:@"info" forKey:@"payload_type"];
     [logData setObject:payload forKey:@"payload"];
@@ -411,6 +411,9 @@
     OTSubscriber* sub = [[OTSubscriber alloc] initWithStream:myStream delegate:self];
     sub.audioLevelDelegate = self;
     sub.networkStatsDelegate = self;
+    NSLog(@"OT subscriber Audio volume before %f", sub.audioVolume);
+    [sub setAudioVolume:100];
+    NSLog(@"OT subscriber Audio volume after %f", sub.audioVolume);
     [_session subscribe:sub error:nil];
 
     if ([[command.arguments objectAtIndex:6] isEqualToString:@"false"]) {

--- a/version.txt
+++ b/version.txt
@@ -2,4 +2,4 @@ v3.4.7
 
 Base SDKs:
 Android: v2.26.0
-iOS: v2.23.0
+iOS: v2.26.0

--- a/version.txt
+++ b/version.txt
@@ -1,5 +1,5 @@
-v3.4.6
+v3.4.7
 
 Base SDKs:
-Android: v2.22.3
+Android: v2.26.0
 iOS: v2.23.0


### PR DESCRIPTION
This MR addresses the following,
- Updated Vonage Android SDK from "com.opentok.android:opentok-android-sdk:2.21.4" to "com.opentok.android:opentok-android-sdk:2.26.0"
- With the intent to maximise the volume output for Vonage calls, as suggested to use the SetAudioVolume method exposed by the new SDK, as soon as the new subscriber is getting created, we have set the volume to 100 (setAudioVolume(100)). As per the dev testing and testing by some other team members in the team, we feel that audio has not increased substantially. We still have made setAudioVolume(100) just in case during a call session SDK tries to alter it somehow. 