### PR TITLE
Upgraded opentok version to 2.27.0 for DEV-14727

### DIFF
--- a/build-extras.gradle
+++ b/build-extras.gradle
@@ -23,5 +23,5 @@ allprojects {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.opentok.android:opentok-android-sdk:2.26.0'
+    implementation 'com.opentok.android:opentok-android-sdk:2.27.0'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-opentok",
-  "version": "3.4.13",
+  "version": "3.4.14",
   "description": "Add live video streaming to your Cordova Application",
   "scripts": {
     "version": "node ./scripts/version-sync.js"

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-opentok"
-    version="3.4.13">
+    version="3.4.14">
 
     <name>OpenTokCordovaPlugin</name>
     <description>Add live video streaming to your Cordova Application</description>

--- a/version.txt
+++ b/version.txt
@@ -1,5 +1,5 @@
-v3.4.7
+v3.4.14
 
 Base SDKs:
-Android: v2.26.0
+Android: v2.27.0
 iOS: v2.26.0


### PR DESCRIPTION
This MR addresses the following :
- For DEV-14727 : we found that there were audio issues at CC2 end and with the SDK upgrade to 2.27.0, we didnt face any such issues.
- Thus it was decided to upgrade opentok from 2.26.0 to 2.27.0.
- Also updated plugin version after the upgrade. 
- This is for merging to 01 branch.