### PR TITLE
Set publisher publish video to false to release use of the device camera when the call ends

### DIFF
--- a/src/android/VonageActivity.java
+++ b/src/android/VonageActivity.java
@@ -262,6 +262,7 @@ public class VonageActivity extends Activity implements Session.ConnectionListen
 
         if (publisher != null) {
             publisherViewContainer.removeView(publisher.getView());
+            publisher.setPublishVideo(false);
         }
     }
 


### PR DESCRIPTION
…era when a call is ended

<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure you followed the Contribution Guidelines. Which can be found here:
https://github.com/opentok/cordova-plugin-opentok/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [ ] Code must follow existing styling conventions
- [ ] Added a descriptive commit message

### Solves issue(s)
<!--- Mention the GitHub issues here -->