### PR TITLE
Fix android resource imports for non-PCM apps

### DIFF
--- a/hooks/fix-android-resource-imports.js
+++ b/hooks/fix-android-resource-imports.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const cordovaAndroidPath = [`platforms`, `android`, `app`, `src`, `main`, `java`, `com`, `tokbox`, `cordova`];
+
+function extractBundleIdFromConfigXml(configXmlPath) {
+    const pattern = /<widget id="([^"]+)"/;
+    const data = fs.readFileSync(configXmlPath, 'utf8');
+    return pattern.exec(data)[1];
+}
+
+function rewriteResourceImports(bundleId, sourceFileDirectory, sourceFileNames) {
+    for (const fileName of sourceFileNames) {
+        console.log(`rewriting resource imports for ${fileName} in directory ${sourceFileDirectory}`);
+        const filePath = path.resolve(sourceFileDirectory, fileName);
+        const input = fs.readFileSync(filePath, 'utf8');
+        const output = input.replace(/import com\.hrs\.patient\.R;/gm, `import ${bundleId}.R;`);
+        fs.writeFileSync(filePath, output, 'utf8');
+    }
+}
+
+function main(context) {
+    const cdvRoot = context && context.opts && context.opts.projectRoot;
+    const projectRoot = cdvRoot || process.cwd();
+    const configXmlPath = path.resolve(projectRoot, 'config.xml');
+    const bundleId = extractBundleIdFromConfigXml(configXmlPath);
+    console.log(`extracted app bundle id: ${bundleId}`);
+    const sourceFileDirectory = path.resolve(projectRoot, ...cordovaAndroidPath);
+    rewriteResourceImports(bundleId, sourceFileDirectory, [`VonageActivity.java`]);
+}
+
+module.exports = main;

--- a/plugin.xml
+++ b/plugin.xml
@@ -10,6 +10,7 @@
     <keywords>opentok,tokbox</keywords>
 
     <platform name="android">
+      <hook type="after_platform_add" src="hooks/fix-android-resource-imports.js" />
       <framework src="build-extras.gradle" custom="true" type="gradleReference" />
       <framework src="com.android.support:appcompat-v7:23.1.0" />
       <framework src="com.android.support:design:23.0.0" />


### PR DESCRIPTION
add hook to rewrite resource imports dynamically based on the root project's bundle ID

<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure you followed the Contribution Guidelines. Which can be found here:
https://github.com/opentok/cordova-plugin-opentok/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [ ] Code must follow existing styling conventions
- [ ] Added a descriptive commit message

### Solves issue(s)
<!--- Mention the GitHub issues here -->